### PR TITLE
Add multi-page PAGES list to skia-rs-wasm LayersPanel

### DIFF
--- a/skia-rs-wasm/src/lib/components/LayersPanel/LayersPanel.tsx
+++ b/skia-rs-wasm/src/lib/components/LayersPanel/LayersPanel.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback, useMemo, useState } from 'react'
 import type { IndexedNode, IndexedPage } from '../../worker/types'
+import type { PenpotNode, PenpotPage } from 'penpot-exporter/types'
 import { useSnapshot } from 'valtio'
 import { docProxy, getActiveOrSinglePageId } from '../../renderer/store/doc-proxy'
 import { setSelectedIds } from '../../renderer/store/document-selection'
@@ -11,27 +12,12 @@ import { orderedNodesFromPage } from '../../renderer/store/ordered-page-nodes'
 import { FloatingEditorRail } from '../EditorShell/floating-editor-rail'
 import { cn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
 import { ScrollArea } from '@/components/ui/scroll-area'
-import { Separator } from '@/components/ui/separator'
-import { ChevronRight, Layers } from 'lucide-react'
+import { ChevronDown, ChevronRight, FileText, Plus } from 'lucide-react'
 import { commitPageMetadataUpdate } from '../../renderer/properties/commit-page-properties'
+import { setActivePage, addPage } from '../../page-crud'
 
 const ROOT_UUID = '00000000-0000-0000-0000-000000000000'
-
-function normalizeHex(input: string): string {
-  let s = input.trim()
-  if (!s.startsWith('#')) s = `#${s}`
-  if (/^#[0-9A-Fa-f]{3}$/.test(s)) {
-    const r = s[1],
-      g = s[2],
-      b = s[3]
-    s = `#${r}${r}${g}${g}${b}${b}`
-  }
-  if (/^#[0-9A-Fa-f]{6}$/.test(s)) return s
-  return '#FFFFFF'
-}
 
 export interface LayersPanelProps {
   className?: string
@@ -42,14 +28,16 @@ export function LayersPanel({ className }: LayersPanelProps) {
   const selectedIds = useMemo(() => new Set(doc.selectedIds), [doc.selectedIds])
 
   const [collapsed, setCollapsed] = useState(false)
-  const [pageSectionOpen, setPageSectionOpen] = useState(true)
-  const [pageNameDraft, setPageNameDraft] = useState<string | null>(null)
-  const [pageBgDraft, setPageBgDraft] = useState<string | null>(null)
+  const [pagesOpen, setPagesOpen] = useState(true)
+  const [layersOpen, setLayersOpen] = useState(true)
 
-  const resolvePageId = useCallback((): string | null => getActiveOrSinglePageId(), [])
+  const [editingPageId, setEditingPageId] = useState<string | null>(null)
+  const [editingName, setEditingName] = useState('')
 
-  const pid = resolvePageId()
+  const pid = doc.currentPageId ?? getActiveOrSinglePageId()
   const page: IndexedPage | undefined = pid ? doc.pageMap.get(pid) : undefined
+
+  const pages = useMemo(() => Array.from(doc.pageMap.values()), [doc.pageMap])
 
   const currentPageNodes = useMemo(() => {
     if (!page) return
@@ -63,54 +51,72 @@ export function LayersPanel({ className }: LayersPanelProps) {
 
   const layerCount = shapeLayers.length
 
-  const pageName = pageNameDraft ?? page?.name ?? 'Page'
-  const pageBg = pageBgDraft ?? page?.background ?? '#FFFFFF'
-  const displayPageName = page?.name ?? 'Page'
+  const onSelectPage = useCallback((id: string) => {
+    if (id === docProxy.currentPageId) return
+    void setActivePage(id)
+  }, [])
 
-  const commitPageName = useCallback(async () => {
-    if (!pid) return
-    const p = docProxy.pageMap.get(pid)
-    if (!p) return
-    const trimmed = pageName.trim()
-    if (trimmed !== (p.name ?? '')) {
-      await commitPageMetadataUpdate(pid, p, { name: trimmed || 'Page' })
+  const onCreatePage = useCallback(async () => {
+    const newId = crypto.randomUUID()
+    const name = `Page ${docProxy.pageMap.size + 1}`
+    const rootFrame: PenpotNode = {
+      id: ROOT_UUID,
+      name: 'Root',
+      type: 'frame',
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+      parentId: undefined,
+      selrect: { x: 0, y: 0, width: 800, height: 600, x1: 0, y1: 0, x2: 800, y2: 600 },
+      points: [
+        { x: 0, y: 0 },
+        { x: 800, y: 0 },
+        { x: 800, y: 600 },
+        { x: 0, y: 600 },
+      ],
     }
-    setPageNameDraft(null)
-  }, [pageName, pid])
-
-  const commitPageBackground = useCallback(async () => {
-    if (!pid) return
-    const p = docProxy.pageMap.get(pid)
-    if (!p) return
-    const next = normalizeHex(pageBg)
-    if (next !== (p.background ?? '#FFFFFF')) {
-      await commitPageMetadataUpdate(pid, p, { background: next })
+    const newPage: PenpotPage = {
+      id: newId,
+      name,
+      children: [rootFrame],
+      background: '#FFFFFF',
     }
-    setPageBgDraft(null)
-  }, [pageBg, pid])
+    await addPage(newPage)
+    await setActivePage(newId)
+  }, [])
 
-  const onPageBgColorPick = useCallback(
-    (hex: string) => {
-      setPageBgDraft(hex)
-      if (!pid) return
-      const p = docProxy.pageMap.get(pid)
-      if (!p) return
-      void commitPageMetadataUpdate(pid, p, { background: hex })
+  const onStartRename = useCallback((id: string, current: string) => {
+    setEditingPageId(id)
+    setEditingName(current)
+  }, [])
+
+  const commitRename = useCallback(
+    async (id: string) => {
+      const p = docProxy.pageMap.get(id)
+      if (!p) {
+        setEditingPageId(null)
+        return
+      }
+      const trimmed = editingName.trim()
+      if (trimmed && trimmed !== (p.name ?? '')) {
+        await commitPageMetadataUpdate(id, p, { name: trimmed })
+      }
+      setEditingPageId(null)
     },
-    [pid],
+    [editingName],
   )
 
   const onLayerRowClick = useCallback((id: string) => {
     setSelectedIds(new Set([id]))
   }, [])
 
-  const footer =
-    layerCount === 1 ? '1 layer' : `${layerCount} layers`
+  const footer = layerCount === 1 ? '1 layer' : `${layerCount} layers`
 
   return (
     <FloatingEditorRail
       side="left"
-      title="Layers"
+      title="Design"
       collapsed={collapsed}
       onCollapsedChange={setCollapsed}
       footer={footer}
@@ -118,94 +124,173 @@ export function LayersPanel({ className }: LayersPanelProps) {
       className={cn('min-h-0', className)}
     >
       <ScrollArea className="min-h-0 flex-1">
-        <div className="space-y-1 p-2">
-          <div className="rounded-lg border border-transparent">
-            <button
-              type="button"
-              className="flex w-full items-center gap-1 rounded-md px-1 py-1.5 text-left text-sm hover:bg-muted/60"
-              onClick={() => setPageSectionOpen((o) => !o)}
-              aria-expanded={pageSectionOpen}
-            >
-              <ChevronRight
-                className={cn('size-4 shrink-0 text-muted-foreground transition-transform', pageSectionOpen && 'rotate-90')}
-              />
-              <Layers className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-              <span className="min-w-0 flex-1 truncate font-medium text-foreground">{displayPageName}</span>
-            </button>
+        <div className="space-y-2 p-2">
+          {/* PAGES Section */}
+          <section>
+            <div className="flex items-center gap-0.5 pl-1 pr-0.5">
+              <button
+                type="button"
+                className="flex flex-1 items-center gap-1 rounded-md py-1 pl-0.5 pr-1 text-left hover:text-foreground"
+                onClick={() => setPagesOpen((o) => !o)}
+                aria-expanded={pagesOpen}
+              >
+                {pagesOpen ? (
+                  <ChevronDown className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+                ) : (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+                )}
+                <span className="text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Pages
+                </span>
+              </button>
+              <span className="min-w-4 text-right text-xs tabular-nums text-muted-foreground">
+                {doc.pageMap.size}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="text-muted-foreground"
+                aria-label="Add page"
+                title="Add page"
+                onClick={() => void onCreatePage()}
+              >
+                <Plus />
+              </Button>
+            </div>
 
-            {pageSectionOpen && (
-              <div className="space-y-3 border-l border-border/60 pb-2 pl-6 pr-1 pt-0.5">
-                {!page && <p className="text-xs text-muted-foreground">Loading page…</p>}
-                {page && (
-                  <>
-                    <div>
-                      {shapeLayers.length === 0 ? (
-                        <p className="text-xs text-muted-foreground">No layers yet</p>
+            {pagesOpen && (
+              <ul className="mt-0.5 list-none space-y-0.5 p-0">
+                {pages.length === 0 && (
+                  <li className="px-2 py-1 text-xs text-muted-foreground">No pages yet</li>
+                )}
+                {pages.map((p) => {
+                  const active = p.id === doc.currentPageId
+                  const isEditing = editingPageId === p.id
+                  return (
+                    <li key={p.id}>
+                      {isEditing ? (
+                        <div
+                          className={cn(
+                            'flex items-center gap-2 rounded-md px-2 py-1.5',
+                            active
+                              ? 'bg-blue-100 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300'
+                              : 'bg-muted/40',
+                          )}
+                        >
+                          <FileText
+                            className={cn(
+                              'size-4 shrink-0',
+                              active
+                                ? 'text-blue-700 dark:text-blue-300'
+                                : 'text-muted-foreground',
+                            )}
+                            aria-hidden
+                          />
+                          <input
+                            autoFocus
+                            type="text"
+                            className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+                            value={editingName}
+                            onChange={(e) => setEditingName(e.target.value)}
+                            onBlur={() => void commitRename(p.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault()
+                                void commitRename(p.id)
+                              } else if (e.key === 'Escape') {
+                                e.preventDefault()
+                                setEditingPageId(null)
+                              }
+                            }}
+                          />
+                        </div>
                       ) : (
-                        <ul className="list-none space-y-0.5 p-0">
-                          {shapeLayers.map((node: IndexedNode) => {
-                            const active = selectedIds.has(node.id)
-                            return (
-                              <li key={node.id}>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="sm"
-                                  className={cn(
-                                    'h-8 w-full justify-start px-2 font-normal',
-                                    active && 'bg-muted/80 text-foreground',
-                                  )}
-                                  onClick={() => onLayerRowClick(node.id)}
-                                >
-                                  <span className="truncate">{node.name ?? 'Shape'}</span>
-                                </Button>
-                              </li>
-                            )
-                          })}
-                        </ul>
+                        <button
+                          type="button"
+                          className={cn(
+                            'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+                            active
+                              ? 'bg-blue-100 font-medium text-blue-700 dark:bg-blue-950/40 dark:text-blue-300'
+                              : 'text-foreground hover:bg-muted/60',
+                          )}
+                          onClick={() => onSelectPage(p.id)}
+                          onDoubleClick={() => onStartRename(p.id, p.name ?? 'Page')}
+                          title={p.name ?? 'Page'}
+                        >
+                          <FileText
+                            className={cn(
+                              'size-4 shrink-0',
+                              active
+                                ? 'text-blue-700 dark:text-blue-300'
+                                : 'text-muted-foreground',
+                            )}
+                            aria-hidden
+                          />
+                          <span className="min-w-0 flex-1 truncate">{p.name ?? 'Page'}</span>
+                        </button>
                       )}
-                    </div>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </section>
 
-                    <Separator />
-                    <div className="space-y-2">
-                      <Label htmlFor="layers-page-name" className="text-xs">
-                        Page name
-                      </Label>
-                      <Input
-                        id="layers-page-name"
-                        value={pageName}
-                        onChange={(e) => setPageNameDraft(e.target.value)}
-                        onBlur={() => void commitPageName()}
-                        className="h-8 text-sm"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="layers-page-bg" className="text-xs">
-                        Background
-                      </Label>
-                      <div className="flex min-w-0 items-center gap-2">
-                        <input
-                          id="layers-page-bg"
-                          type="color"
-                          className="h-8 w-10 shrink-0 cursor-pointer rounded border border-border bg-transparent p-0.5"
-                          value={normalizeHex(pageBg)}
-                          onChange={(e) => onPageBgColorPick(e.target.value)}
-                          aria-label="Background color"
-                        />
-                        <Input
-                          className="h-8 min-w-0 flex-1 font-mono text-xs"
-                          value={pageBg}
-                          onChange={(e) => setPageBgDraft(e.target.value)}
-                          onBlur={() => void commitPageBackground()}
-                          placeholder="#FFFFFF"
-                        />
-                      </div>
-                    </div>
-                  </>
+          {/* LAYERS Section */}
+          <section>
+            <div className="flex items-center pl-1 pr-0.5">
+              <button
+                type="button"
+                className="flex flex-1 items-center gap-1 rounded-md py-1 pl-0.5 pr-1 text-left hover:text-foreground"
+                onClick={() => setLayersOpen((o) => !o)}
+                aria-expanded={layersOpen}
+              >
+                {layersOpen ? (
+                  <ChevronDown className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+                ) : (
+                  <ChevronRight className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+                )}
+                <span className="text-[0.7rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Layers
+                </span>
+              </button>
+            </div>
+
+            {layersOpen && (
+              <div className="mt-0.5">
+                {!page && (
+                  <p className="px-2 py-1 text-xs text-muted-foreground">Loading page…</p>
+                )}
+                {page && shapeLayers.length === 0 && (
+                  <p className="px-2 py-1 text-xs text-muted-foreground">No layers yet</p>
+                )}
+                {page && shapeLayers.length > 0 && (
+                  <ul className="list-none space-y-0.5 p-0">
+                    {shapeLayers.map((node: IndexedNode) => {
+                      const active = selectedIds.has(node.id)
+                      return (
+                        <li key={node.id}>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className={cn(
+                              'h-8 w-full justify-start px-2 font-normal',
+                              active && 'bg-muted/80 text-foreground',
+                            )}
+                            onClick={() => onLayerRowClick(node.id)}
+                          >
+                            <span className="truncate">{node.name ?? 'Shape'}</span>
+                          </Button>
+                        </li>
+                      )
+                    })}
+                  </ul>
                 )}
               </div>
             )}
-          </div>
+          </section>
         </div>
       </ScrollArea>
     </FloatingEditorRail>


### PR DESCRIPTION
## Summary
- Rework the left rail's page block into a **PAGES** section with a page count, a `+` add button, and per-page rows showing a document icon and name. The active page is highlighted with a rounded blue pill.
- Add a sibling **LAYERS** section below that shows the current page's layer tree (behavior unchanged — still uses `orderedNodesFromPage` and `setSelectedIds`).
- Wire the UI directly to the existing store APIs already exported from `skia-rs-wasm/src/lib/page-crud.ts`: click-to-switch uses `setActivePage`, the `+` button uses `addPage`, double-click a row to rename (committed via `commitPageMetadataUpdate`).
- Remove the inline Page name / Background editor from this panel — those fields live in the right-side panel, so keeping them here was duplicated UI.

No changes to the underlying document model, worker, or renderer — this is presentation-only wiring over already-exported store APIs.

## Test plan
- [x] Panel renders with `PAGES` header, count `1`, and `+` button on initial load
- [x] Clicking `+` creates a new page, increments the count, and makes the new page active (confirmed via `docProxy` inspection)
- [x] Clicking a different page row switches `docProxy.currentPageId` and swaps the LAYERS list to that page's shapes
- [x] Double-clicking a page row enters inline rename; Enter / blur commits, Escape cancels
- [x] Adding a shape to a page shows it in the LAYERS section; switching pages empties / repopulates the list as expected
- [x] Collapse / expand toggles on PAGES and LAYERS sections work independently
- [ ] Reviewer: sanity-check the active-pill colors under dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)