### PR TITLE
skia-rs-wasm: redesign right-panel Layout section, add Appearance, fix overflow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "figma_plugin_fe"]
 	path = figma_plugin_fe
 	url = https://github.com/ux-plugin/figma_plugin_fe.git
+[submodule "skia-rs-wasm/packages/penpot-exporter"]
+	path = skia-rs-wasm/packages/penpot-exporter
+	url = https://github.com/ux-plugin/penpot-exporter-figma-plugin.git

--- a/skia-rs-wasm/pnpm-lock.yaml
+++ b/skia-rs-wasm/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: 16.5.0
       penpot-exporter:
         specifier: workspace:*
-        version: link:packages/penpot-exporter-figma-plugin
+        version: link:packages/penpot-exporter
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -124,7 +124,7 @@ importers:
         specifier: ^5.0.10
         version: 5.0.10(@types/react@19.2.9)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
 
-  packages/penpot-exporter-figma-plugin:
+  packages/penpot-exporter:
     dependencies:
       '@create-figma-plugin/ui':
         specifier: ^4.0
@@ -5153,8 +5153,8 @@ snapshots:
 
   '@babel/generator@7.28.6':
     dependencies:
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -5240,7 +5240,7 @@ snapshots:
   '@babel/helpers@7.28.6':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.28.6':
     dependencies:
@@ -5295,17 +5295,17 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
-      '@babel/parser': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@babel/traverse@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -6856,7 +6856,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
@@ -6992,9 +6992,9 @@ snapshots:
   '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.8.1)':
     dependencies:
       '@babel/generator': 7.28.6
-      '@babel/parser': 7.28.6
+      '@babel/parser': 7.29.0
       '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
+      '@babel/types': 7.29.0
       javascript-natural-sort: 0.7.1
       lodash-es: 4.17.23
       minimatch: 9.0.5

--- a/skia-rs-wasm/src/components/ui/scroll-area.tsx
+++ b/skia-rs-wasm/src/components/ui/scroll-area.tsx
@@ -16,7 +16,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 [&>div]:!block [&>div]:!min-w-0"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/NodePropertyPanel.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/NodePropertyPanel.tsx
@@ -1,6 +1,6 @@
 import type { RectLikeNode } from '../../renderer/properties/panel-utils'
-import { Separator } from '@/components/ui/separator'
 import { NodeIdentitySection } from './Sections/NodeIdentitySection'
+import { AppearanceSection } from './Sections/AppearanceSection'
 import { NodeLayoutSection } from './Sections/NodeLayoutSection'
 import { FillsSection } from './Sections/FillsSection'
 import { StrokesSection } from './Sections/StrokesSection'
@@ -23,7 +23,7 @@ export function NodePropertyPanel({ nodeId, initialNode, readOnly }: NodePropert
 
       <NodeIdentitySection nodeId={nodeId} readOnly={readOnly} initialNode={initialNode} />
 
-      <Separator />
+      <AppearanceSection nodeId={nodeId} initialNode={initialNode} readOnly={readOnly} />
 
       <NodeLayoutSection nodeId={nodeId} initialNode={initialNode} readOnly={readOnly} />
 

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/RightSidePanel.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/RightSidePanel.tsx
@@ -222,7 +222,7 @@ export function RightSidePanel({ className }: RightSidePanelProps) {
         data-right-side-panel
         className={cn('min-h-0', className)}
       >
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {singleId && !isRoot && (
             <p
               className="shrink-0 truncate border-b border-border px-3 py-1.5 text-xs text-muted-foreground"
@@ -231,8 +231,8 @@ export function RightSidePanel({ className }: RightSidePanelProps) {
               {singleId.slice(0, 8)}…
             </p>
           )}
-          <ScrollArea className="min-h-0 flex-1">
-            <div className="space-y-4 p-3">
+          <ScrollArea className="min-h-0 min-w-0 flex-1">
+            <div className="min-w-0 space-y-4 p-3">
               {node ? (
                 <NodePropertyPanel key={singleId} nodeId={singleId} initialNode={node} readOnly={readOnly} />
               ) : null}

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/AppearanceSection.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/AppearanceSection.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useSelector } from '@xstate/react'
+import type { PenpotNode } from 'penpot-exporter/types'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Separator } from '@/components/ui/separator'
+import { applyTransformToNode } from '../../../renderer/geom/apply-transform-to-node'
+import { rotationMatrixAroundPoint } from '../../../renderer/geom/matrix'
+import { useCanvasActor } from '../../../renderer/machine/canvas-actor-context'
+import {
+  commitNodePartialUpdate,
+  getCommittedNodeOnActivePage,
+  rectLayoutPartial,
+} from '../../../renderer/properties/commit-node-properties'
+import type { RectLikeNode } from '../../../renderer/properties/panel-utils'
+import { getActiveOrSinglePageId } from '../../../renderer/store/doc-proxy'
+import { rotatePreviewDeltaDeg as rotatePreviewDeltaDegSignal } from '../../../renderer/signals/pointer'
+import { useSignalCoalesced } from '../../../renderer/signals/use-signal-coalesced'
+
+type SizeDraft = { width: number; height: number; rotation: number }
+
+export interface AppearanceSectionProps {
+  nodeId: string
+  initialNode: RectLikeNode
+  readOnly: boolean
+}
+
+export function AppearanceSection({ nodeId, initialNode, readOnly }: AppearanceSectionProps) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [draft, setDraft] = useState<SizeDraft | null>(null)
+
+  const committed: SizeDraft = {
+    width: initialNode.width ?? 100,
+    height: initialNode.height ?? 100,
+    rotation: initialNode.rotation ?? 0,
+  }
+
+  const { width, height, rotation } = draft ?? committed
+
+  const canvasActor = useCanvasActor()
+  const isMoving = useSelector(canvasActor, (s) => s.matches('moving'))
+  const isRotating = useSelector(canvasActor, (s) => s.matches('rotating'))
+  const rotatePreviewDeltaDeg = useSignalCoalesced(rotatePreviewDeltaDegSignal)
+
+  const liveRotationPartial = useMemo((): Partial<PenpotNode> | null => {
+    if (readOnly || !isRotating) return null
+    const node = initialNode as PenpotNode
+    const sr = node.selrect as
+      | { x?: number; y?: number; width?: number; height?: number }
+      | undefined
+    if (!sr) return null
+    const x0 = sr.x ?? 0
+    const y0 = sr.y ?? 0
+    const w0 = sr.width ?? 0
+    const h0 = sr.height ?? 0
+    if (w0 <= 0 || h0 <= 0) return null
+    const cx = x0 + w0 / 2
+    const cy = y0 + h0 / 2
+    return applyTransformToNode(node, rotationMatrixAroundPoint(cx, cy, rotatePreviewDeltaDeg))
+  }, [readOnly, initialNode, isRotating, rotatePreviewDeltaDeg])
+
+  const rotationDisplay =
+    liveRotationPartial != null && typeof liveRotationPartial.rotation === 'number'
+      ? liveRotationPartial.rotation
+      : rotation
+
+  const fieldsDisabled = readOnly || isMoving || isRotating
+
+  const commit = useCallback(async () => {
+    if (readOnly || !draft) return
+    const before = getCommittedNodeOnActivePage(nodeId)
+    const pid = getActiveOrSinglePageId()
+    if (!before || !pid) return
+    const x = (before as { x?: number }).x ?? 0
+    const y = (before as { y?: number }).y ?? 0
+    await commitNodePartialUpdate(
+      nodeId,
+      before,
+      rectLayoutPartial(x, y, draft.width, draft.height, draft.rotation),
+      pid,
+    )
+    setDraft(null)
+  }, [readOnly, nodeId, draft])
+
+  const patchDraft = (patch: Partial<SizeDraft>) =>
+    setDraft((d) => ({ ...(d ?? committed), ...patch }))
+
+  return (
+    <>
+      <Separator />
+      <div className="min-w-0 space-y-2">
+        <div className="flex items-center justify-between gap-2 py-0.5">
+          <button
+            type="button"
+            className="flex min-h-8 flex-1 items-center gap-1 text-left text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-expanded={!collapsed}
+          >
+            {collapsed ? (
+              <ChevronRight className="size-3.5 shrink-0" aria-hidden />
+            ) : (
+              <ChevronDown className="size-3.5 shrink-0" aria-hidden />
+            )}
+            Appearance
+          </button>
+        </div>
+
+        {!collapsed && (
+          <>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label htmlFor="rsp-w">W</Label>
+                <Input
+                  id="rsp-w"
+                  type="number"
+                  disabled={fieldsDisabled}
+                  value={Number.isFinite(width) ? width : 0}
+                  onChange={(e) =>
+                    patchDraft({ width: Math.max(1, parseFloat(e.target.value) || 1) })
+                  }
+                  onBlur={() => void commit()}
+                />
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="rsp-h">H</Label>
+                <Input
+                  id="rsp-h"
+                  type="number"
+                  disabled={fieldsDisabled}
+                  value={Number.isFinite(height) ? height : 0}
+                  onChange={(e) =>
+                    patchDraft({ height: Math.max(1, parseFloat(e.target.value) || 1) })
+                  }
+                  onBlur={() => void commit()}
+                />
+              </div>
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="rsp-rot">Rotation (deg)</Label>
+              <Input
+                id="rsp-rot"
+                type="number"
+                disabled={fieldsDisabled}
+                value={Number.isFinite(rotationDisplay) ? rotationDisplay : 0}
+                onChange={(e) => patchDraft({ rotation: parseFloat(e.target.value) || 0 })}
+                onBlur={() => void commit()}
+              />
+            </div>
+          </>
+        )}
+      </div>
+    </>
+  )
+}

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/LayoutFlexBody.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/LayoutFlexBody.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { PenpotNode } from 'penpot-exporter/types'
+import {
+  AlignEndHorizontal,
+  AlignEndVertical,
+  AlignHorizontalJustifyCenter,
+  AlignHorizontalJustifyEnd,
+  AlignHorizontalJustifyStart,
+  AlignHorizontalSpaceAround,
+  AlignHorizontalSpaceBetween,
+  AlignStartHorizontal,
+  AlignStartVertical,
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  StretchHorizontal,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  commitNodePartialUpdate,
+  getCommittedNodeOnActivePage,
+} from '@/lib/renderer/properties/commit-node-properties'
+import { getActiveOrSinglePageId } from '@/lib/renderer/store/doc-proxy'
+import type { RectLikeNode } from '@/lib/renderer/properties/panel-utils'
+
+type FlexDir = 'row' | 'row-reverse' | 'column' | 'column-reverse'
+type WrapType = 'wrap' | 'nowrap'
+type JustifyContent =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly'
+type AlignItems = 'start' | 'center' | 'end' | 'stretch'
+type Gap = { rowGap: number; columnGap: number }
+type Padding = { p1: number; p2: number; p3: number; p4: number }
+
+interface LayoutView {
+  layoutFlexDir?: FlexDir
+  layoutWrapType?: WrapType
+  layoutJustifyContent?: JustifyContent
+  layoutAlignItems?: AlignItems
+  layoutGap?: Gap
+  layoutPadding?: Padding
+}
+
+export interface LayoutFlexBodyProps {
+  nodeId: string
+  initialNode: RectLikeNode
+  readOnly: boolean
+}
+
+const DIRECTIONS: ReadonlyArray<{ value: FlexDir; Icon: typeof ArrowRight; label: string }> = [
+  { value: 'row', Icon: ArrowRight, label: 'Row' },
+  { value: 'row-reverse', Icon: ArrowLeft, label: 'Row reverse' },
+  { value: 'column', Icon: ArrowDown, label: 'Column' },
+  { value: 'column-reverse', Icon: ArrowUp, label: 'Column reverse' },
+]
+
+const JUSTIFY_ROW: ReadonlyArray<{
+  value: JustifyContent
+  Icon: typeof ArrowRight
+  label: string
+}> = [
+  { value: 'start', Icon: AlignHorizontalJustifyStart, label: 'Start' },
+  { value: 'center', Icon: AlignHorizontalJustifyCenter, label: 'Center' },
+  { value: 'end', Icon: AlignHorizontalJustifyEnd, label: 'End' },
+  { value: 'space-between', Icon: AlignHorizontalSpaceBetween, label: 'Space between' },
+  { value: 'space-around', Icon: AlignHorizontalSpaceAround, label: 'Space around' },
+  { value: 'space-evenly', Icon: StretchHorizontal, label: 'Space evenly' },
+]
+
+const ALIGN_ROW: ReadonlyArray<{
+  value: AlignItems
+  Icon: typeof ArrowRight
+  label: string
+}> = [
+  { value: 'start', Icon: AlignStartHorizontal, label: 'Start' },
+  { value: 'center', Icon: AlignEndVertical, label: 'Center' },
+  { value: 'end', Icon: AlignEndHorizontal, label: 'End' },
+  { value: 'stretch', Icon: AlignStartVertical, label: 'Stretch' },
+]
+
+function readLayout(node: RectLikeNode): LayoutView {
+  return node as LayoutView
+}
+
+export function LayoutFlexBody({ nodeId, initialNode, readOnly }: LayoutFlexBodyProps) {
+  const initial = readLayout(initialNode)
+  const [direction, setDirection] = useState<FlexDir>(initial.layoutFlexDir ?? 'row')
+  const [wrap, setWrap] = useState<WrapType>(initial.layoutWrapType ?? 'nowrap')
+  const [justify, setJustify] = useState<JustifyContent>(
+    (initial.layoutJustifyContent as JustifyContent | undefined) ?? 'start',
+  )
+  const [align, setAlign] = useState<AlignItems>(initial.layoutAlignItems ?? 'start')
+  const [gap, setGap] = useState<number>(initial.layoutGap?.rowGap ?? 0)
+  const [padding, setPadding] = useState<number>(initial.layoutPadding?.p1 ?? 0)
+  const [gapDraft, setGapDraft] = useState<string | null>(null)
+  const [paddingDraft, setPaddingDraft] = useState<string | null>(null)
+
+  useEffect(() => {
+    /* eslint-disable react-hooks/set-state-in-effect -- mirrors external document updates */
+    const v = readLayout(initialNode)
+    setDirection(v.layoutFlexDir ?? 'row')
+    setWrap(v.layoutWrapType ?? 'nowrap')
+    setJustify((v.layoutJustifyContent as JustifyContent | undefined) ?? 'start')
+    setAlign(v.layoutAlignItems ?? 'start')
+    setGap(v.layoutGap?.rowGap ?? 0)
+    setPadding(v.layoutPadding?.p1 ?? 0)
+    /* eslint-enable react-hooks/set-state-in-effect */
+  }, [initialNode])
+
+  const commit = useCallback(
+    async (partial: Partial<PenpotNode>) => {
+      if (readOnly) return
+      const before = getCommittedNodeOnActivePage(nodeId)
+      const pid = getActiveOrSinglePageId()
+      if (!before || !pid) return
+      await commitNodePartialUpdate(nodeId, before, partial, pid)
+    },
+    [nodeId, readOnly],
+  )
+
+  const onDirection = (v: FlexDir) => {
+    setDirection(v)
+    void commit({ layoutFlexDir: v } as Partial<PenpotNode>)
+  }
+  const onWrap = (v: WrapType) => {
+    setWrap(v)
+    void commit({ layoutWrapType: v } as Partial<PenpotNode>)
+  }
+  const onJustify = (v: JustifyContent) => {
+    setJustify(v)
+    void commit({ layoutJustifyContent: v } as Partial<PenpotNode>)
+  }
+  const onAlign = (v: AlignItems) => {
+    setAlign(v)
+    void commit({ layoutAlignItems: v } as Partial<PenpotNode>)
+  }
+  const commitGap = (value: number) => {
+    setGap(value)
+    void commit({ layoutGap: { rowGap: value, columnGap: value } } as Partial<PenpotNode>)
+  }
+  const commitPadding = (value: number) => {
+    setPadding(value)
+    void commit({
+      layoutPadding: { p1: value, p2: value, p3: value, p4: value },
+    } as Partial<PenpotNode>)
+  }
+
+  return (
+    <div className="min-w-0 space-y-3">
+      <div className="flex min-w-0 items-center justify-between rounded-md bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary">
+        <span className="truncate">Flex layout</span>
+        <span className="shrink-0 text-[10px] text-primary/70">flex</span>
+      </div>
+
+      <ControlBlock label="Direction">
+        <IconRow
+          items={DIRECTIONS}
+          columns={4}
+          value={direction}
+          onChange={onDirection}
+          disabled={readOnly}
+        />
+      </ControlBlock>
+
+      <div className="flex w-full overflow-hidden rounded-lg border border-input">
+        <WrapButton active={wrap === 'nowrap'} onClick={() => onWrap('nowrap')} disabled={readOnly}>
+          No wrap
+        </WrapButton>
+        <WrapButton active={wrap === 'wrap'} onClick={() => onWrap('wrap')} disabled={readOnly}>
+          Wrap
+        </WrapButton>
+      </div>
+
+      <ControlBlock label="Justify content">
+        <IconRow
+          items={JUSTIFY_ROW}
+          columns={6}
+          value={justify}
+          onChange={onJustify}
+          disabled={readOnly}
+        />
+      </ControlBlock>
+
+      <ControlBlock label="Align items">
+        <IconRow
+          items={ALIGN_ROW}
+          columns={4}
+          value={align}
+          onChange={onAlign}
+          disabled={readOnly}
+        />
+      </ControlBlock>
+
+      <ControlBlock label="Gap">
+        <NumberWithSuffix
+          id="rsp-flex-gap"
+          value={gapDraft ?? String(gap)}
+          disabled={readOnly}
+          suffix="px"
+          onChange={(s) => setGapDraft(s)}
+          onBlur={() => {
+            const n = Math.max(0, parseFloat(gapDraft ?? String(gap)) || 0)
+            setGapDraft(null)
+            commitGap(n)
+          }}
+        />
+      </ControlBlock>
+
+      <ControlBlock label="Padding">
+        <NumberWithSuffix
+          id="rsp-flex-padding"
+          value={paddingDraft ?? String(padding)}
+          disabled={readOnly}
+          suffix="px"
+          onChange={(s) => setPaddingDraft(s)}
+          onBlur={() => {
+            const n = Math.max(0, parseFloat(paddingDraft ?? String(padding)) || 0)
+            setPaddingDraft(null)
+            commitPadding(n)
+          }}
+        />
+      </ControlBlock>
+    </div>
+  )
+}
+
+function ControlBlock({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] font-medium tracking-wide text-muted-foreground uppercase">
+        {label}
+      </p>
+      {children}
+    </div>
+  )
+}
+
+interface IconItem<V extends string> {
+  value: V
+  Icon: typeof ArrowRight
+  label: string
+}
+
+function IconRow<V extends string>({
+  items,
+  columns,
+  value,
+  onChange,
+  disabled,
+}: {
+  items: ReadonlyArray<IconItem<V>>
+  columns: number
+  value: V
+  onChange: (v: V) => void
+  disabled?: boolean
+}) {
+  return (
+    <div
+      className="grid w-full gap-1 rounded-md bg-muted/60 p-1"
+      style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+    >
+      {items.map(({ value: v, Icon, label }) => {
+        const active = v === value
+        return (
+          <Button
+            key={v}
+            type="button"
+            variant={active ? 'secondary' : 'ghost'}
+            size="icon-sm"
+            aria-pressed={active}
+            aria-label={label}
+            title={label}
+            disabled={disabled}
+            onClick={() => onChange(v)}
+            className="w-full"
+          >
+            <Icon className="size-3.5" aria-hidden />
+          </Button>
+        )
+      })}
+    </div>
+  )
+}
+
+function WrapButton({
+  active,
+  onClick,
+  disabled,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={
+        'h-7 flex-1 px-3 text-xs font-medium transition-colors ' +
+        (active
+          ? 'bg-secondary text-foreground'
+          : 'bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground') +
+        ' disabled:pointer-events-none disabled:opacity-50'
+      }
+    >
+      {children}
+    </button>
+  )
+}
+
+function NumberWithSuffix({
+  id,
+  value,
+  onChange,
+  onBlur,
+  disabled,
+  suffix,
+}: {
+  id: string
+  value: string
+  onChange: (s: string) => void
+  onBlur: () => void
+  disabled?: boolean
+  suffix: string
+}) {
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        type="number"
+        min={0}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        className="pr-8"
+      />
+      <span className="pointer-events-none absolute inset-y-0 right-2.5 flex items-center text-xs text-muted-foreground">
+        {suffix}
+      </span>
+    </div>
+  )
+}

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/LayoutGridBody.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/LayoutGridBody.tsx
@@ -1,0 +1,5 @@
+export function LayoutGridBody() {
+  return (
+    <p className="text-xs text-muted-foreground">Grid layout controls coming soon.</p>
+  )
+}

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/LayoutModeToggle.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/LayoutModeToggle.tsx
@@ -1,0 +1,43 @@
+import { LayoutDashboard, LayoutGrid } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { LayoutMode } from './layout-mode'
+
+export interface LayoutModeToggleProps {
+  mode: LayoutMode | null
+  onChange: (mode: LayoutMode | null) => void
+  disabled?: boolean
+}
+
+const MODES: ReadonlyArray<{
+  mode: LayoutMode
+  Icon: typeof LayoutDashboard
+  label: string
+}> = [
+  { mode: 'flex', Icon: LayoutDashboard, label: 'Flex layout' },
+  { mode: 'grid', Icon: LayoutGrid, label: 'Grid layout' },
+]
+
+export function LayoutModeToggle({ mode, onChange, disabled }: LayoutModeToggleProps) {
+  return (
+    <div className="flex gap-1">
+      {MODES.map(({ mode: m, Icon, label }) => {
+        const active = mode === m
+        return (
+          <Button
+            key={m}
+            type="button"
+            variant={active ? 'secondary' : 'ghost'}
+            size="icon-sm"
+            aria-pressed={active}
+            aria-label={active ? `Disable ${label.toLowerCase()}` : label}
+            title={active ? `Disable ${label.toLowerCase()}` : label}
+            disabled={disabled}
+            onClick={() => onChange(active ? null : m)}
+          >
+            <Icon className="size-3.5" aria-hidden />
+          </Button>
+        )
+      })}
+    </div>
+  )
+}

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/NodeLayoutSection.tsx
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/NodeLayoutSection.tsx
@@ -1,25 +1,17 @@
-import { useCallback, useMemo, useState } from 'react'
-import { useSelector } from '@xstate/react'
+import { useCallback, useState } from 'react'
 import type { PenpotNode } from 'penpot-exporter/types'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { applyTransformToNode } from '../../../renderer/geom/apply-transform-to-node'
-import { rotationMatrixAroundPoint, translateMatrix } from '../../../renderer/geom/matrix'
-import { useCanvasActor } from '../../../renderer/machine/canvas-actor-context'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { Separator } from '@/components/ui/separator'
 import {
   commitNodePartialUpdate,
   getCommittedNodeOnActivePage,
-  rectLayoutPartial,
 } from '../../../renderer/properties/commit-node-properties'
 import type { RectLikeNode } from '../../../renderer/properties/panel-utils'
 import { getActiveOrSinglePageId } from '../../../renderer/store/doc-proxy'
-import {
-  movePreviewWorldDelta as movePreviewWorldDeltaSignal,
-  rotatePreviewDeltaDeg as rotatePreviewDeltaDegSignal,
-} from '../../../renderer/signals/pointer'
-import { useSignalCoalesced } from '../../../renderer/signals/use-signal-coalesced'
-
-type LayoutDraft = { x: number; y: number; width: number; height: number; rotation: number }
+import { LayoutFlexBody } from './LayoutFlexBody'
+import { LayoutGridBody } from './LayoutGridBody'
+import { LayoutModeToggle } from './LayoutModeToggle'
+import { getLayoutMode, modeSwitchPartial, type LayoutMode } from './layout-mode'
 
 export interface NodeLayoutSectionProps {
   nodeId: string
@@ -28,145 +20,46 @@ export interface NodeLayoutSectionProps {
 }
 
 export function NodeLayoutSection({ nodeId, initialNode, readOnly }: NodeLayoutSectionProps) {
-  const [draft, setDraft] = useState<LayoutDraft | null>(null)
+  const [collapsed, setCollapsed] = useState(false)
+  const mode = getLayoutMode(initialNode)
 
-  const committed: LayoutDraft = {
-    x: initialNode.x ?? 0,
-    y: initialNode.y ?? 0,
-    width: initialNode.width ?? 100,
-    height: initialNode.height ?? 100,
-    rotation: initialNode.rotation ?? 0,
-  }
-
-  const { x, y, width, height, rotation } = draft ?? committed
-
-  const canvasActor = useCanvasActor()
-  const isMoving = useSelector(canvasActor, (s) => s.matches('moving'))
-  const isRotating = useSelector(canvasActor, (s) => s.matches('rotating'))
-  const rotatePreviewDeltaDeg = useSignalCoalesced(rotatePreviewDeltaDegSignal)
-  const movePreviewCoalesced = useSignalCoalesced(movePreviewWorldDeltaSignal)
-
-  const liveLayoutPartial = useMemo((): Partial<PenpotNode> | null => {
-    if (readOnly) return null
-    const node = initialNode as PenpotNode
-    if (isRotating) {
-      const sr = node.selrect as
-        | { x?: number; y?: number; width?: number; height?: number }
-        | undefined
-      if (!sr) return null
-      const x0 = sr.x ?? 0
-      const y0 = sr.y ?? 0
-      const w0 = sr.width ?? 0
-      const h0 = sr.height ?? 0
-      if (w0 <= 0 || h0 <= 0) return null
-      const cx = x0 + w0 / 2
-      const cy = y0 + h0 / 2
-      return applyTransformToNode(node, rotationMatrixAroundPoint(cx, cy, rotatePreviewDeltaDeg))
-    }
-    if (isMoving) {
-      return applyTransformToNode(
-        node,
-        translateMatrix(movePreviewCoalesced.x, movePreviewCoalesced.y),
-      )
-    }
-    return null
-  }, [readOnly, initialNode, isRotating, isMoving, rotatePreviewDeltaDeg, movePreviewCoalesced])
-
-  const xDisplay =
-    liveLayoutPartial != null && typeof liveLayoutPartial.x === 'number' ? liveLayoutPartial.x : x
-  const yDisplay =
-    liveLayoutPartial != null && typeof liveLayoutPartial.y === 'number' ? liveLayoutPartial.y : y
-  const widthDisplay =
-    liveLayoutPartial != null && typeof liveLayoutPartial.width === 'number'
-      ? liveLayoutPartial.width
-      : width
-  const heightDisplay =
-    liveLayoutPartial != null && typeof liveLayoutPartial.height === 'number'
-      ? liveLayoutPartial.height
-      : height
-  const rotationDisplay =
-    liveLayoutPartial != null && typeof liveLayoutPartial.rotation === 'number'
-      ? liveLayoutPartial.rotation
-      : rotation
-
-  const layoutFieldsDisabled = readOnly || isMoving || isRotating
-
-  const commitLayout = useCallback(async () => {
-    if (readOnly || !draft) return
-    const before = getCommittedNodeOnActivePage(nodeId)
-    const pid = getActiveOrSinglePageId()
-    if (!before || !pid) return
-    await commitNodePartialUpdate(
-      nodeId,
-      before,
-      rectLayoutPartial(draft.x, draft.y, draft.width, draft.height, draft.rotation),
-      pid,
-    )
-    setDraft(null)
-  }, [readOnly, nodeId, draft])
-
-  const patchDraft = (patch: Partial<LayoutDraft>) =>
-    setDraft((d) => ({ ...(d ?? committed), ...patch }))
+  const onModeChange = useCallback(
+    async (next: LayoutMode | null) => {
+      if (readOnly || next === mode) return
+      const before = getCommittedNodeOnActivePage(nodeId)
+      const pid = getActiveOrSinglePageId()
+      if (!before || !pid) return
+      const partial = modeSwitchPartial(next, before as RectLikeNode) as Partial<PenpotNode>
+      await commitNodePartialUpdate(nodeId, before, partial, pid)
+    },
+    [nodeId, readOnly, mode],
+  )
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label htmlFor="rsp-x">X</Label>
-          <Input
-            id="rsp-x"
-            type="number"
-            disabled={layoutFieldsDisabled}
-            value={Number.isFinite(xDisplay) ? xDisplay : 0}
-            onChange={(e) => patchDraft({ x: parseFloat(e.target.value) || 0 })}
-            onBlur={() => void commitLayout()}
-          />
-        </div>
-        <div className="space-y-1">
-          <Label htmlFor="rsp-y">Y</Label>
-          <Input
-            id="rsp-y"
-            type="number"
-            disabled={layoutFieldsDisabled}
-            value={Number.isFinite(yDisplay) ? yDisplay : 0}
-            onChange={(e) => patchDraft({ y: parseFloat(e.target.value) || 0 })}
-            onBlur={() => void commitLayout()}
-          />
-        </div>
-        <div className="space-y-1">
-          <Label htmlFor="rsp-w">W</Label>
-          <Input
-            id="rsp-w"
-            type="number"
-            disabled={layoutFieldsDisabled}
-            value={Number.isFinite(widthDisplay) ? widthDisplay : 0}
-            onChange={(e) => patchDraft({ width: Math.max(1, parseFloat(e.target.value) || 1) })}
-            onBlur={() => void commitLayout()}
-          />
-        </div>
-        <div className="space-y-1">
-          <Label htmlFor="rsp-h">H</Label>
-          <Input
-            id="rsp-h"
-            type="number"
-            disabled={layoutFieldsDisabled}
-            value={Number.isFinite(heightDisplay) ? heightDisplay : 0}
-            onChange={(e) => patchDraft({ height: Math.max(1, parseFloat(e.target.value) || 1) })}
-            onBlur={() => void commitLayout()}
-          />
-        </div>
-      </div>
-
+      <Separator />
       <div className="space-y-2">
-        <Label htmlFor="rsp-rot">Rotation (deg)</Label>
-        <Input
-          id="rsp-rot"
-          type="number"
-          disabled={layoutFieldsDisabled}
-          value={Number.isFinite(rotationDisplay) ? rotationDisplay : 0}
-          onChange={(e) => patchDraft({ rotation: parseFloat(e.target.value) || 0 })}
-          onBlur={() => void commitLayout()}
-        />
+        <div className="flex items-center justify-between gap-2 py-0.5">
+          <button
+            type="button"
+            className="flex min-h-8 flex-1 items-center gap-1 text-left text-xs font-medium tracking-wide text-muted-foreground uppercase hover:text-foreground"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-expanded={!collapsed}
+          >
+            {collapsed ? (
+              <ChevronRight className="size-3.5 shrink-0" aria-hidden />
+            ) : (
+              <ChevronDown className="size-3.5 shrink-0" aria-hidden />
+            )}
+            Layout
+          </button>
+          <LayoutModeToggle mode={mode} onChange={onModeChange} disabled={readOnly} />
+        </div>
+
+        {!collapsed && mode === 'flex' && (
+          <LayoutFlexBody nodeId={nodeId} initialNode={initialNode} readOnly={readOnly} />
+        )}
+        {!collapsed && mode === 'grid' && <LayoutGridBody />}
       </div>
     </>
   )

--- a/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/layout-mode.ts
+++ b/skia-rs-wasm/src/lib/components/RightSidePanel/Sections/layout-mode.ts
@@ -1,0 +1,52 @@
+import type { PenpotNode } from 'penpot-exporter/types'
+import type { RectLikeNode } from '../../../renderer/properties/panel-utils'
+
+export type LayoutMode = 'flex' | 'grid'
+
+type LayoutFieldsView = {
+  layoutFlexDir?: unknown
+  layoutGridDir?: unknown
+  layoutWrapType?: unknown
+  layoutJustifyContent?: unknown
+  layoutAlignItems?: unknown
+  layoutGap?: unknown
+  layoutPadding?: unknown
+}
+
+export function getLayoutMode(node: RectLikeNode): LayoutMode | null {
+  const n = node as LayoutFieldsView
+  if (n.layoutFlexDir) return 'flex'
+  if (n.layoutGridDir) return 'grid'
+  return null
+}
+
+export function modeSwitchPartial(
+  mode: LayoutMode | null,
+  before: RectLikeNode,
+): Partial<PenpotNode> {
+  const b = before as LayoutFieldsView
+  const patch: Record<string, unknown> = {}
+
+  if (mode == null) {
+    patch.layoutFlexDir = null
+    patch.layoutGridDir = null
+    return patch as Partial<PenpotNode>
+  }
+
+  if (mode === 'flex') {
+    patch.layoutGridDir = null
+    patch.layoutFlexDir = (b.layoutFlexDir as string | undefined) ?? 'row'
+    if (b.layoutWrapType == null) patch.layoutWrapType = 'nowrap'
+    if (b.layoutJustifyContent == null) patch.layoutJustifyContent = 'start'
+    if (b.layoutAlignItems == null) patch.layoutAlignItems = 'start'
+    if (b.layoutGap == null) patch.layoutGap = { rowGap: 0, columnGap: 0 }
+    if (b.layoutPadding == null)
+      patch.layoutPadding = { p1: 0, p2: 0, p3: 0, p4: 0 }
+    return patch as Partial<PenpotNode>
+  }
+
+  // grid
+  patch.layoutFlexDir = null
+  patch.layoutGridDir = (b.layoutGridDir as string | undefined) ?? 'row'
+  return patch as Partial<PenpotNode>
+}


### PR DESCRIPTION
### Related Ticket

_N/A_

### Summary

Reworks the Layout section in the right-side design panel to match the Penpot flex/grid panel pattern, factors out a new Appearance section for W/H/Rotation, and fixes a horizontal overflow in the panel.

- **Layout mode toggle** in the section header: two lucide icons (`LayoutDashboard` for flex, `LayoutGrid` for grid). Active icon is highlighted; clicking it again deactivates, falling back to absolute positioning.
- **Flex body** (direction, wrap, justify content, align items, gap, padding) with icon-button groups distributed evenly across each row via CSS grid (`grid-template-columns: repeat(N, minmax(0, 1fr))`).
- **Grid body** is a stub (`"Grid layout controls coming soon"`) for parity while the grid controls are built out.
- **New `AppearanceSection`** above Layout holding W / H / Rotation so size is always editable regardless of layout mode. X/Y drops out with the removal of the absolute body (position is mode-specific).
- **Panel overflow fix**: the Radix `ScrollArea.Viewport` wraps children in a `display: table; min-width: 100%` div by default, so wide intrinsic children (the stroke `<select>`, hex inputs, etc.) leaked past the panel edge. Overrode at the `ScrollArea` primitive (`[&>div]:!block [&>div]:!min-w-0`) and added `min-w-0` guards on the `RightSidePanel` flex wrappers and the `LayoutFlexBody` root.
- **Submodule fix for installs**: registered `penpot-exporter` as a submodule at `skia-rs-wasm/packages/penpot-exporter` (source: `ux-plugin/penpot-exporter-figma-plugin`, whose root `package.json` is `"name": "penpot-exporter"`) so the existing `"penpot-exporter": "workspace:*"` devDependency resolves. Without this, `pnpm install` failed on this branch with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`.

### Steps to reproduce / verify

1. `pnpm install` (should now resolve — would previously fail with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`).
2. `pnpm --filter skia-rs-wasm run dev`, open the app, select a shape.
3. Confirm the right panel renders: **Appearance** (W/H/Rotation) → **Layout** (mode toggle) → Fill → Stroke → Effects.
4. Click the flex icon — flex body appears (direction, wrap, justify, align, gap, padding). Icons in each row are equally spaced.
5. Click the flex icon again — body disappears, shape returns to absolute positioning.
6. Click the grid icon — stub body appears.
7. Resize the panel narrow and widen Fill/Stroke content — nothing should push past the panel edge.
8. Edit W / H / Rotation in Appearance regardless of active mode.

### Checklist

- [x] Choose the correct target branch; use \`develop\` by default.
- [x] Provide a brief summary of the changes introduced.
- [x] Add a detailed explanation of how to reproduce the issue and/or verify the fix, if applicable.
- [ ] Include screenshots or videos, if applicable.
- [ ] Add or modify existing integration tests in case of bugs or new features, if applicable.
- [x] Refactor any modified SCSS files following the refactor guide. _(no SCSS touched; skia-rs-wasm uses Tailwind.)_
- [ ] Check CI passes successfully.
- [ ] Update the \`CHANGES.md\` file, referencing the related GitHub issue, if applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)